### PR TITLE
Follow groonga log change

### DIFF
--- a/lib/fluent/plugin/parser_groonga_log.rb
+++ b/lib/fluent/plugin/parser_groonga_log.rb
@@ -37,7 +37,7 @@ module Fluent
 
       def parse(text)
         @parser.parse(text) do |statistic|
-          timestamp = statistic.delete("timestamp")
+          timestamp = statistic.delete(:timestamp)
           event_time = Fluent::EventTime.from_time(timestamp)
           yield event_time, statistic
         end

--- a/test/plugin/test_parser_groonga_log.rb
+++ b/test/plugin/test_parser_groonga_log.rb
@@ -6,16 +6,16 @@ class GroongaLogParserTest < Test::Unit::TestCase
     Fluent::Test.setup
     @parser = create_driver({})
     @expected = {
-      "year" => 2017,
-      "month" => 7,
-      "day" => 19,
-      "hour" => 14,
-      "minutes" => 41,
-      "seconds" => 5,
-      "micro_seconds" => 663978,
-      "log_level" => :notice,
-      "context_id" => "18c61700",
-      "message" => "spec:2:update:Object:32(type):8",
+      :year => 2017,
+      :month => 7,
+      :day => 19,
+      :hour => 14,
+      :minute => 41,
+      :second => 5,
+      :micro_second => 663978,
+      :log_level => :notice,
+      :context_id => "18c61700",
+      :message => "spec:2:update:Object:32(type):8",
     }
     @parser.configure({})
   end


### PR DESCRIPTION
Groonga log implementation is changed to use symbol.

ref: https://github.com/groonga/groonga-log/pull/4/commits/d8e6e02d1921e4acb5ea7c6986825d8c27ea43b6