### PR TITLE
Stringify keys

### DIFF
--- a/lib/fluent/plugin/parser_groonga_log.rb
+++ b/lib/fluent/plugin/parser_groonga_log.rb
@@ -36,7 +36,7 @@ module Fluent
           record = statistic.to_h
           timestamp = record.delete(:timestamp)
           event_time = Fluent::EventTime.from_time(timestamp)
-          yield event_time, record
+          yield event_time, Hash[record.collect{|k,v| [k.to_s, v]}]
         end
       end
     end

--- a/test/plugin/test_parser_groonga_log.rb
+++ b/test/plugin/test_parser_groonga_log.rb
@@ -13,16 +13,16 @@ class GroongaLogParserTest < Test::Unit::TestCase
     @parser.instance.parse(log) do |time, record|
       timestamp = Time.local(2017, 7, 19, 14, 41, 5, 663978)
       expected = {
-        :year => 2017,
-        :month => 7,
-        :day => 19,
-        :hour => 14,
-        :minute => 41,
-        :second => 5,
-        :micro_second => 663978,
-        :log_level => :notice,
-        :context_id => "18c61700",
-        :message => "spec:2:update:Object:32(type):8",
+        "year" => 2017,
+        "month" => 7,
+        "day" => 19,
+        "hour" => 14,
+        "minute" => 41,
+        "second" => 5,
+        "micro_second" => 663978,
+        "log_level" => :notice,
+        "context_id" => "18c61700",
+        "message" => "spec:2:update:Object:32(type):8",
       }
       assert_equal([
                      Fluent::EventTime.from_time(timestamp),


### PR DESCRIPTION
Fluentd assumes that record keys are String not Symbol.