### PR TITLE
Set string expression of timestamp into record

### DIFF
--- a/lib/fluent/plugin/parser_groonga_log.rb
+++ b/lib/fluent/plugin/parser_groonga_log.rb
@@ -36,7 +36,11 @@ module Fluent
           event_time = Fluent::EventTime.from_time(statistic.timestamp)
           record = {}
           statistic.each_pair do |member, value|
-            record[member.to_s] = value
+            if value.kind_of?(Time)
+              record[member.to_s] = value.iso8601
+            else
+              record[member.to_s] = value
+            end
           end
           yield event_time, record
         end

--- a/test/plugin/test_parser_groonga_log.rb
+++ b/test/plugin/test_parser_groonga_log.rb
@@ -13,7 +13,7 @@ class GroongaLogParserTest < Test::Unit::TestCase
     @parser.instance.parse(log) do |time, record|
       timestamp = Time.local(2017, 7, 19, 14, 41, 5, 663978)
       expected = {
-        "timestamp" => timestamp,
+        "timestamp" => timestamp.iso8601,
         "log_level" => :notice,
         "context_id" => "18c61700",
         "message" => "spec:2:update:Object:32(type):8",


### PR DESCRIPTION
Time object should not be member of record. It causes "undefined
 method `to_msgpack`" error because Time object is not defined in
msgpack format spec.

